### PR TITLE
Add plausible.io analytics

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
     </style>
     {{- block "head" . }}{{ end -}}
     {{- if hugo.IsProduction -}}
-    <script async defer data-domain="wikiotics.org" src="https://plausible.io/js/plausible.js"></script>
+    <script async defer data-domain="wikiotics.org" src="https://plausible.wikiotics.org/js/index.js"></script>
     {{- end }}
   </head>
   <body class="bg-washed-blue nested-copy-line-height nested-headline-line-height nested-list navy">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,9 @@
       h6 { font-weight: bold; font-size: .875rem; }
     </style>
     {{- block "head" . }}{{ end -}}
+    {{- if hugo.IsProduction -}}
+    <script async defer data-domain="wikiotics.org" src="https://plausible.io/js/plausible.js"></script>
+    {{- end }}
   </head>
   <body class="bg-washed-blue nested-copy-line-height nested-headline-line-height nested-list navy">
     <header class="bg-lightest-blue pa4 cf">


### PR DESCRIPTION
This pull request adds analytics from [Plausible](https://plausible.io/).  They have an option for the dashboard to be public, which I plan to enable.